### PR TITLE
Fixed HKPG and LC1 bugs from 24hr file chunking 

### DIFF
--- a/src/edu/ucsc/barrel/cdf_gen/LevelOne.java
+++ b/src/edu/ucsc/barrel/cdf_gen/LevelOne.java
@@ -615,7 +615,7 @@ public class LevelOne{
       var = cdf.getVariable("LC1");
       System.out.println("LC1...");
       var.putHyperData(
-         0, numOfRecs, 1, 
+         var.getNumWrittenRecords(), numOfRecs, 1, 
          new long[] {0}, 
          new long[] {1}, 
          new long[] {1}, 

--- a/src/edu/ucsc/barrel/cdf_gen/LevelTwo.java
+++ b/src/edu/ucsc/barrel/cdf_gen/LevelTwo.java
@@ -778,7 +778,6 @@ public class LevelTwo{
       double[][] 
          chan_edges = new double[numOfRecs][5],
          lc_scaled = new double[4][numOfRecs];
-      int[] tempLC = new int[4];
       double scint_temp = 20, dpu_temp = 20, peak = -1;
       
       int[] 
@@ -841,7 +840,7 @@ public class LevelTwo{
       var = cdf.getVariable("LC1");
       System.out.println("LC1...");
       var.putHyperData(
-         0, numOfRecs, 1, 
+         var.getNumWrittenRecords(), numOfRecs, 1, 
          new long[] {0}, 
          new long[] {1}, 
          new long[] {1}, 


### PR DESCRIPTION
A few typos were left over from making midnight-to-midnight files that have been fixed here. The frameGroup variable for the HKPG CDF file in both L1 and L2 had not been filled. The LC1 variable was still getting the full 'day' worth of data rather than being started after midnight.
