### PR TITLE
Use high PPS values in timing models. 

### DIFF
--- a/src/edu/ucsc/barrel/cdf_gen/ExtractTiming.java
+++ b/src/edu/ucsc/barrel/cdf_gen/ExtractTiming.java
@@ -145,7 +145,12 @@ public class ExtractTiming {
 
          //figure out if pps is valid 
          pps = (short)data.pps[rec_1Hz_i];
-         if((pps <= MINPPS) || (pps >= MAXPPS)){continue;}
+         if((pps <= MINPPS) || (pps >= MAXPPS)){
+            //check if pps is high because it came super early so the
+            //dpu didnt have a chance to write "0"
+            if(pps == 65535){pps = 0;} 
+            else{continue;}
+         }
 
          //get number of weeks since GPS_START_TIME
          week = (short)data.weeks[rec_mod40_i];

--- a/src/edu/ucsc/barrel/cdf_gen/LevelTwo.java
+++ b/src/edu/ucsc/barrel/cdf_gen/LevelTwo.java
@@ -80,7 +80,7 @@ public class LevelTwo{
 
       //calculate yesterday and tomorrow from today's date
       int year, month, day;
-      year = today/10000;
+      year = today / 10000;
       month = (today - (year * 10000)) / 100;
       day = today - (year * 10000) - (month * 100);
       dateObj.clear();


### PR DESCRIPTION
pps = 65535 indicates that the pps signal came during the first 0.25ms of the frame meaning it should be changed to pps = 0 for the purpose of timing calculations.
